### PR TITLE
Treat units info as nu, make nu a list rather than single function

### DIFF
--- a/data_prototype/patches.py
+++ b/data_prototype/patches.py
@@ -45,12 +45,12 @@ class PatchWrapper(ProxyWrapper):
     }
 
     def __init__(self, data: DataContainer, nus=None, /, **kwargs):
-        super().__init__(data, nus)
+        super().__init__(data, nus, xunits=self._xunits, yunits=self._yunits)
         self._wrapped_instance = self._wrapped_class([0, 0], 0, 0, **kwargs)
 
     @_stale_wrapper
     def draw(self, renderer):
-        self._update_wrapped(self._query_and_transform(renderer, xunits=self._xunits, yunits=self._yunits))
+        self._update_wrapped(self._query_and_transform(renderer))
         return self._wrapped_instance.draw(renderer)
 
     def _update_wrapped(self, data):

--- a/data_prototype/wrappers.py
+++ b/data_prototype/wrappers.py
@@ -4,7 +4,6 @@ import inspect
 import numpy as np
 
 from cachetools import LFUCache
-from collections.abc import Sequence
 from functools import partial, wraps
 
 import matplotlib as mpl
@@ -48,6 +47,7 @@ class _Axes(Protocol):
 class _Aritst(Protocol):
     axes: _Axes
 
+
 def _make_param_name(k, func):
     def wrapped(**kwargs):
         (arg,) = kwargs.values()
@@ -56,8 +56,10 @@ def _make_param_name(k, func):
     wrapped.__signature__ = inspect.Signature([inspect.Parameter(k, inspect.Parameter.POSITIONAL_OR_KEYWORD)])
     return wrapped
 
+
 def _make_identity(k):
     return _make_param_name(k, lambda x: x)
+
 
 def _forwarder(forwards, cls=None):
     if cls is None:
@@ -246,7 +248,7 @@ class PathCollectionWrapper(ProxyWrapper):
     )
 
     def __init__(self, data: DataContainer, nus=None, /, **kwargs):
-        super().__init__(data, nus, xunits = ("x",), yunits = ("y",))
+        super().__init__(data, nus, xunits=("x",), yunits=("y",))
         self._wrapped_instance = self._wrapped_class([], **kwargs)
         self._wrapped_instance.set_transform(mtransforms.IdentityTransform())
 


### PR DESCRIPTION
This is mostly a proof of concept/concrete implementation that can be discussed for the idea of allowing `nu` functions to actually be lists of functions applied successively.

As part of this, the treatment of units has been moved to be in the list of `nu` functions, which allows transformations to happen either pre- or post- unit conversion, based on the order in the list.

@tacaswell has stated "nu is a property of the artist, the unit convesion is a property of the host Axes", indicating that perhaps this is not the "correct" way to to treat unit conversions.

I do wish to challenge this thought at least a little bit: the actual call to convert units has a signature that is compatible with `nu` (although admittedly it is a bound method rather than a pure function).
I further wonder if the key to resolving unit inconsistencies is to handle the units separate from at least some of the existing units machinery and coax the existing machinery to work with the new system rather than the other way around. (Note, that is not to say I want _users_ to have to change their code, but rather just that we don't tie ourselves down too early.)

Now... this implementation was pretty hastily put together and none of our currently implemented examples _actually_ use units yet, so it's not even particularly well tested.
Additionally, the implementation conflicts with changes to `nu` proposed in #15.

