### PR TITLE
Rewrap (with black) to 88 chars instead of 115

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ default_language_version:
     python: python3
 repos:
   - repo: https://github.com/ambv/black
-    rev: stable
+    rev: 23.3.0
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -10,6 +10,6 @@ repos:
     hooks:
       - id: flake8
   - repo: https://github.com/kynan/nbstripout
-    rev: 0.3.9
+    rev: 0.6.1
     hooks:
       - id: nbstripout

--- a/data_prototype/containers.py
+++ b/data_prototype/containers.py
@@ -117,7 +117,9 @@ class RandomContainer:
         coord_transform: _MatplotlibTransform,
         size: Tuple[int, int],
     ) -> Tuple[Dict[str, Any], Union[str, int]]:
-        return {k: np.random.randn(*d.shape) for k, d in self._desc.items()}, str(uuid.uuid4())
+        return {k: np.random.randn(*d.shape) for k, d in self._desc.items()}, str(
+            uuid.uuid4()
+        )
 
     def describe(self) -> Dict[str, Desc]:
         return dict(self._desc)
@@ -127,9 +129,15 @@ class FuncContainer:
     def __init__(
         self,
         # TODO: is this really the best spelling?!
-        xfuncs: Optional[Dict[str, Tuple[Tuple[Union[str, int], ...], Callable[[Any], Any]]]] = None,
-        yfuncs: Optional[Dict[str, Tuple[Tuple[Union[str, int], ...], Callable[[Any], Any]]]] = None,
-        xyfuncs: Optional[Dict[str, Tuple[Tuple[Union[str, int], ...], Callable[[Any, Any], Any]]]] = None,
+        xfuncs: Optional[
+            Dict[str, Tuple[Tuple[Union[str, int], ...], Callable[[Any], Any]]]
+        ] = None,
+        yfuncs: Optional[
+            Dict[str, Tuple[Tuple[Union[str, int], ...], Callable[[Any], Any]]]
+        ] = None,
+        xyfuncs: Optional[
+            Dict[str, Tuple[Tuple[Union[str, int], ...], Callable[[Any, Any], Any]]]
+        ] = None,
     ):
         """
         A container that wraps several functions.  They are split into 3 categories:
@@ -274,7 +282,10 @@ class SeriesContainer:
         coord_transform: _MatplotlibTransform,
         size: Tuple[int, int],
     ) -> Tuple[Dict[str, Any], Union[str, int]]:
-        return {self._index_name: self._data.index.values, self._col_name: self._data.values}, self._hash_key
+        return {
+            self._index_name: self._data.index.values,
+            self._col_name: self._data.values,
+        }, self._hash_key
 
     def describe(self) -> Dict[str, Desc]:
         return dict(self._desc)

--- a/data_prototype/conversion_node.py
+++ b/data_prototype/conversion_node.py
@@ -50,7 +50,9 @@ class UnionConversionNode(ConversionNode):
         return cls(required, tuple(output), trim_keys, nodes)
 
     def evaluate(self, input: dict[str, Any]) -> dict[str, Any]:
-        return super().evaluate({k: v for n in self.nodes for k, v in n.evaluate(input).items()})
+        return super().evaluate(
+            {k: v for n in self.nodes for k, v in n.evaluate(input).items()}
+        )
 
 
 @dataclass
@@ -66,7 +68,9 @@ class RenameConversionNode(ConversionNode):
         return cls(required, tuple(output), trim_keys, mapping)
 
     def evaluate(self, input: dict[str, Any]) -> dict[str, Any]:
-        return super().evaluate({**input, **{out: input[inp] for (inp, out) in self.mapping.items()}})
+        return super().evaluate(
+            {**input, **{out: input[inp] for (inp, out) in self.mapping.items()}}
+        )
 
 
 @dataclass
@@ -91,7 +95,10 @@ class FunctionConversionNode(ConversionNode):
         return super().evaluate(
             {
                 **input,
-                **{k: func(**{p: input[p] for p in sig.parameters}) for (k, (func, sig)) in self._sigs.items()},
+                **{
+                    k: func(**{p: input[p] for p in sig.parameters})
+                    for (k, (func, sig)) in self._sigs.items()
+                },
             }
         )
 

--- a/data_prototype/patches.py
+++ b/data_prototype/patches.py
@@ -50,7 +50,11 @@ class PatchWrapper(ProxyWrapper):
 
     @_stale_wrapper
     def draw(self, renderer):
-        self._update_wrapped(self._query_and_transform(renderer, xunits=self._xunits, yunits=self._yunits))
+        self._update_wrapped(
+            self._query_and_transform(
+                renderer, xunits=self._xunits, yunits=self._yunits
+            )
+        )
         return self._wrapped_instance.draw(renderer)
 
     def _update_wrapped(self, data):
@@ -75,7 +79,14 @@ class RectangleWrapper(PatchWrapper):
     )
     _xunits = ("x", "width")
     _yunits = ("y", "height")
-    required_keys = PatchWrapper.required_keys | {"x", "y", "width", "height", "angle", "rotation_point"}
+    required_keys = PatchWrapper.required_keys | {
+        "x",
+        "y",
+        "width",
+        "height",
+        "angle",
+        "rotation_point",
+    }
 
     def _update_wrapped(self, data):
         for k, v in data.items():

--- a/data_prototype/tests/test_containers.py
+++ b/data_prototype/tests/test_containers.py
@@ -10,7 +10,9 @@ from .. import containers
 
 @pytest.fixture
 def ac():
-    return containers.ArrayContainer(a=np.arange(5), b=np.arange(42, dtype=float).reshape(6, 7))
+    return containers.ArrayContainer(
+        a=np.arange(5), b=np.arange(42, dtype=float).reshape(6, 7)
+    )
 
 
 def _verify_describe(container):

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -166,7 +166,11 @@ html_theme = "mpl_sphinx_theme"
 #
 html_logo = "_static/logo2.svg"
 html_theme_options = {
-    "logo": {"link": "index", "image_light": "images/logo2.svg", "image_dark": "images/logo_dark.svg"},
+    "logo": {
+        "link": "index",
+        "image_light": "images/logo2.svg",
+        "image_dark": "images/logo_dark.svg",
+    },
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,
@@ -214,7 +218,13 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, "data_prototype.tex", "data_prototype Documentation", "Contributors", "manual"),
+    (
+        master_doc,
+        "data_prototype.tex",
+        "data_prototype Documentation",
+        "Contributors",
+        "manual",
+    ),
 ]
 
 
@@ -222,7 +232,9 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [(master_doc, "data_prototype", "data_prototype Documentation", [author], 1)]
+man_pages = [
+    (master_doc, "data_prototype", "data_prototype Documentation", [author], 1)
+]
 
 
 # -- Options for Texinfo output -------------------------------------------

--- a/examples/2Dfunc.py
+++ b/examples/2Dfunc.py
@@ -21,7 +21,10 @@ fc = FuncContainer(
     xyfuncs={
         "xextent": ((2,), lambda x, y: [x[0], x[-1]]),
         "yextent": ((2,), lambda x, y: [y[0], y[-1]]),
-        "image": (("N", "M"), lambda x, y: np.sin(x).reshape(1, -1) * np.cos(y).reshape(-1, 1)),
+        "image": (
+            ("N", "M"),
+            lambda x, y: np.sin(x).reshape(1, -1) * np.cos(y).reshape(-1, 1),
+        ),
     },
 )
 norm = Normalize(vmin=-1, vmax=1)

--- a/examples/data_frame.py
+++ b/examples/data_frame.py
@@ -16,7 +16,9 @@ from data_prototype.containers import DataFrameContainer
 
 th = np.linspace(0, 4 * np.pi, 256)
 
-dc1 = DataFrameContainer(pd.DataFrame({"x": th, "y": np.cos(th)}), index_name=None, col_names=lambda n: n)
+dc1 = DataFrameContainer(
+    pd.DataFrame({"x": th, "y": np.cos(th)}), index_name=None, col_names=lambda n: n
+)
 
 df = pd.DataFrame(
     {

--- a/examples/errorbar.py
+++ b/examples/errorbar.py
@@ -21,7 +21,9 @@ ylower = y - np.sqrt(y)
 xupper = x + 0.5
 xlower = x - 0.5
 
-ac = ArrayContainer(x=x, y=y, yupper=yupper, ylower=ylower, xlower=xlower, xupper=xupper)
+ac = ArrayContainer(
+    x=x, y=y, yupper=yupper, ylower=ylower, xlower=xlower, xupper=xupper
+)
 
 
 fig, ax = plt.subplots()

--- a/examples/hist.py
+++ b/examples/hist.py
@@ -13,7 +13,9 @@ import numpy as np
 from data_prototype.wrappers import StepWrapper
 from data_prototype.containers import HistContainer
 
-hc = HistContainer(np.concatenate([np.random.randn(5000), 0.1 * np.random.randn(500) + 5]), 25)
+hc = HistContainer(
+    np.concatenate([np.random.randn(5000), 0.1 * np.random.randn(500) + 5]), 25
+)
 
 
 fig, (ax1, ax2) = plt.subplots(1, 2, layout="constrained")

--- a/examples/lissajous.py
+++ b/examples/lissajous.py
@@ -46,7 +46,9 @@ class Lissajous:
     ) -> Tuple[Dict[str, Any], Union[str, int]]:
         def next_time():
             cur_time = time.time()
-            cur_time = np.array([cur_time, cur_time - 0.1, cur_time - 0.2, cur_time - 0.3])
+            cur_time = np.array(
+                [cur_time, cur_time - 0.1, cur_time - 0.2, cur_time - 0.3]
+            )
 
             phase = 15 * np.pi * (self.scale * cur_time % 60) / 150
             marker_obj = mmarkers.MarkerStyle("o")
@@ -54,7 +56,9 @@ class Lissajous:
                 "x": np.cos(5 * phase),
                 "y": np.sin(3 * phase),
                 "sizes": np.array([256]),
-                "paths": [marker_obj.get_path().transformed(marker_obj.get_transform())],
+                "paths": [
+                    marker_obj.get_path().transformed(marker_obj.get_transform())
+                ],
                 "edgecolors": "k",
                 "facecolors": ["#4682b4ff", "#82b446aa", "#46b48288", "#8246b433"],
                 "time": cur_time[0],

--- a/examples/widgets.py
+++ b/examples/widgets.py
@@ -35,7 +35,9 @@ class SliderContainer(FuncContainer):
                     s,
                     # this line binds the correct sliders to the functions
                     # and makes lambdas that match the API FuncContainer needs
-                    lambda x, keys=get_needed_keys(f), f=f: f(x, *(sliders[k].val for k in keys)),
+                    lambda x, keys=get_needed_keys(f), f=f: f(
+                        x, *(sliders[k].val for k in keys)
+                    ),
                 )
                 for k, (s, f) in xfuncs.items()
             },
@@ -104,7 +106,8 @@ fc = SliderContainer(
         "y": (
             ("N",),
             # the y data needs all three sliders
-            lambda t, amplitude, frequency, phase: amplitude * np.sin(2 * np.pi * frequency * t + phase),
+            lambda t, amplitude, frequency, phase: amplitude
+            * np.sin(2 * np.pi * frequency * t + phase),
         ),
         # the color data has to take the x (because reasons), but just
         # needs the phase
@@ -118,7 +121,9 @@ fc = SliderContainer(
 lw = LineWrapper(
     fc,
     # color map phase (scaled to 2pi and wrapped to [0, 1])
-    FunctionConversionNode.from_funcs({"color": lambda color: cmap((color / (2 * np.pi)) % 1)}),
+    FunctionConversionNode.from_funcs(
+        {"color": lambda color: cmap((color / (2 * np.pi)) % 1)}
+    ),
     lw=5,
 )
 ax.add_artist(lw)
@@ -127,6 +132,8 @@ ax.add_artist(lw)
 # Create a `matplotlib.widgets.Button` to reset the sliders to initial values.
 resetax = fig.add_axes([0.8, 0.025, 0.1, 0.04])
 button = Button(resetax, "Reset", hovercolor="0.975")
-button.on_clicked(lambda event: [sld.reset() for sld in (freq_slider, amp_slider, phase_slider)])
+button.on_clicked(
+    lambda event: [sld.reset() for sld in (freq_slider, amp_slider, phase_slider)]
+)
 
 plt.show()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
-line-length = 115
+line-length = 88
 include = '\.pyi?$'
 exclude = '''
 /(

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,11 @@ with open(path.join(here, "README.rst"), encoding="utf-8") as readme_file:
 
 with open(path.join(here, "requirements.txt")) as requirements_file:
     # Parse requirements.txt, ignoring any commented-out lines.
-    requirements = [line for line in requirements_file.read().splitlines() if not line.startswith("#")]
+    requirements = [
+        line
+        for line in requirements_file.read().splitlines()
+        if not line.startswith("#")
+    ]
 
 
 setup(


### PR DESCRIPTION
- Rewrap (with black) to 88 characters

We had gone with 115 early on because we didn't want to be stuck to 79, but since matplotlib upstream went with 88 after consideration (and it is black's default), probably best to be consistent

- update precommit config
