### PR TITLE
CI: Harden GHA configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"      # Location of your workflow files
+    schedule:
+      interval: "weekly"  # Options: daily, weekly, monthly

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v2
       - name: Install Dependencies
         run: |

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,4 +1,6 @@
 name: Check Code Style - BLACK
+permissions:
+  contents: read
 
 on: [push, pull_request]
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,6 @@
 name: Docs
+permissions:
+  contents: read
 
 on: [push, pull_request]
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ jobs:
         run: make -Cdocs singlehtml
       - name: Publish
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/build/singlehtml

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - name: "Set up Python 3.10"
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
 ---
 
 name: Release
+permissions:
+  contents: read
 on:
   release:
     types:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 10
+          persist-credentials: false
 
       - name: Set up Python
         id: setup

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,4 +1,6 @@
 name: Check Code Style - ruff
+permissions:
+  contents: read
 
 on: [push, pull_request]
 

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v2
       - name: Install Dependencies
         run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        persist-credentials: false
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,4 +1,6 @@
 name: Unit Tests
+permissions:
+  contents: read
 
 on: [push, pull_request]
 


### PR DESCRIPTION
Apply recommended hardening steps including:

- pinning to a SHA any actions used
- not persisting the read token on checkout
- setting the default permissions
- adding a depandabot file for GHA
